### PR TITLE
Deploy to heroku

### DIFF
--- a/composeexample/settings.py
+++ b/composeexample/settings.py
@@ -10,6 +10,7 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/2.1/ref/settings/
 """
 
+import django_heroku
 import os
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
@@ -121,3 +122,5 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/2.1/howto/static-files/
 
 STATIC_URL = '/static/'
+
+django_heroku.settings(locals())

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,0 +1,5 @@
+build:
+  docker:
+    web: Dockerfile
+run:
+  web: python manage.py runserver 0.0.0.0:8000

--- a/heroku.yml
+++ b/heroku.yml
@@ -2,4 +2,4 @@ build:
   docker:
     web: Dockerfile
 run:
-  web: python manage.py runserver 0.0.0.0:8000
+  web: python manage.py runserver 0.0.0.0:$PORT

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,7 @@
+dj-database-url==0.5.0
 Django==2.1.7
-psycopg2>=2.7,<3.0
+django-heroku==0.3.1
+gunicorn==19.9.0
+psycopg2==2.7.7
+pytz==2018.9
+whitenoise==4.1.2


### PR DESCRIPTION
ref: #2 

## What I did
### Add postgress add-on

```
$ heroku addons:create heroku-postgresql:hobby-dev
```

ref: https://elements.heroku.com/addons/heroku-postgresql

### Change database at production(heroku)
By using django-heroku
https://github.com/chaspy/ask-python/pull/3/commits/bd1f7db5f86c11e09c556d2f2f49f52ac7d83a7e
https://github.com/chaspy/ask-python/pull/3/commits/05faf9f3008f907013884ae50e43ba3641f3a0d0

If `$DATABASE_URL` exists, it is automatically replace the setting.
ref: https://devcenter.heroku.com/articles/django-app-configuration#settings-py-changes
ref: https://github.com/heroku/django-heroku/blob/v0.3.0/django_heroku/core.py#L65-L69

$ DATABASE_URL was added as config var when installed postgress add-ons.
You can see this value by `heroku config`

### Deploy to heroku

```
$ heroku login
$ heroku git:remote -a askpy
$ git push heroku master
```


I've already pushed to heroku:master. application is working fine! https://askpy.herokuapp.com

@ariririri 
Please review and merge